### PR TITLE
Fix `ctx.delete`

### DIFF
--- a/lib/trailblazer/context/container.rb
+++ b/lib/trailblazer/context/container.rb
@@ -50,8 +50,8 @@ module Trailblazer
         alias_method :store, :[]=
 
         def delete(key)
-          @replica.delete(key)
           @mutable_options.delete(key)
+          @replica.delete(key)
         end
 
         def merge(other_hash)

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -123,8 +123,9 @@ class ContextWithIndifferentAccessTest < Minitest::Spec
 
 # delete
     ctx[:model] = Object
-    ctx.delete 'model'
+    value = ctx.delete 'model'
 
+    _(value).must_equal Object
     _(ctx.key?(:model)).must_equal false
     _(ctx.key?("model")).must_equal false
 
@@ -202,8 +203,9 @@ class ContextWithIndifferentAccessTest < Minitest::Spec
 
 # delete
     ctx[:result] = Object
-    ctx.delete :result
+    value = ctx.delete :result
 
+    _(value).must_equal Object
     _(ctx.key?(:result)).must_equal false
     _(ctx.key?("result")).must_equal false
 


### PR DESCRIPTION
Fix `ctx.delete` call to return the value being deleted from `ctx`.